### PR TITLE
Cleared RegistrationData usage documentation

### DIFF
--- a/MangoPay.SDK/Entities/PUT/CardRegistrationPutDTO.cs
+++ b/MangoPay.SDK/Entities/PUT/CardRegistrationPutDTO.cs
@@ -6,7 +6,7 @@ namespace MangoPay.SDK.Entities.PUT
     /// <summary>Card registration PUT entity.</summary>
     public class CardRegistrationPutDTO : EntityPutBase
     {
-        /// <summary>Registration data.</summary>
+        /// <summary>Registration data. This have to be prefixed by "data=".</summary>
         public String RegistrationData { get; set; }
     }
 }


### PR DESCRIPTION
I got difficulties using the SDK with the [card registration](https://docs.mangopay.com/api-references/card-registration/) (`Edit the « CardRegistration » Object (POST method) with the « RegistrationData » just received (7.8. in the diagram)`). Calling the support, the problem has been found. The problem is the CardRegistrationPutDTO.RegistrationData property should not contains the data directly, but the data prefixed by "data=".
I think it could be considered a bug, but changing the SDK would be a breaking change. The least is to update the XmlDoc of the RegistrationData property.