### PR TITLE
Fix: Ambiguous call won't build on VS2015

### DIFF
--- a/MangoPay.SDK/Core/APIs/ApiBase.cs
+++ b/MangoPay.SDK/Core/APIs/ApiBase.cs
@@ -270,7 +270,7 @@ namespace MangoPay.SDK.Core.APIs
         protected ListPaginated<T> GetList<T>(MethodKey methodKey, Pagination pagination)
             where T : EntityBase, new()
         {
-            return GetList<T>(methodKey, pagination, null);
+            return GetList<T>(methodKey, pagination, sort: null);
         }
 
         /// <summary>Saves the Dto instance.</summary>


### PR DESCRIPTION
I tried to build the project in Visual Studio 2015, but this ambiguous call was not building.
This fix won't change anything, but will build in VS2015.