### PR TITLE
Expose rate-limiting info

### DIFF
--- a/MangoPay.SDK/Core/LastRequestInfo.cs
+++ b/MangoPay.SDK/Core/LastRequestInfo.cs
@@ -1,0 +1,13 @@
+﻿using RestSharp;
+
+namespace MangoPay.SDK.Core
+{
+    public class LastRequestInfo
+    {
+        public IRestRequest Request { get; set; }    
+        public IRestResponse Response { get; set; }
+        public string RateLimitingCallsAllowed { get; set; }
+        public string RateLimitingCallsRemaining { get; set; }
+        public string RateLimitingTimeTillReset { get; set; }
+    }
+}

--- a/MangoPay.SDK/Core/RestTool.cs
+++ b/MangoPay.SDK/Core/RestTool.cs
@@ -369,7 +369,7 @@ namespace MangoPay.SDK.Core
                     _log.Debug("CurrentBody: /body is null/");
                 }
             }
-
+            
             IRestResponse<U> restResponse = client.Execute<U>(restRequest);
             responseObject = restResponse.Data;
 
@@ -389,9 +389,23 @@ namespace MangoPay.SDK.Core
                 _log.Debug("Response object: " + responseObject.ToString());
             }
 
+            SetLastRequestInfo(restRequest, restResponse);
+
             this.CheckResponseCode(restResponse.Content);
 
             return responseObject;
+        }
+
+        private void SetLastRequestInfo(IRestRequest request, IRestResponse response)
+        {
+            _root.LastRequestInfo = new LastRequestInfo() {Request = request, Response = response};
+
+            _root.LastRequestInfo.RateLimitingCallsAllowed =
+                response.Headers.FirstOrDefault(h => h.Name == "X-RateLimit-Limit")?.Value?.ToString();
+            _root.LastRequestInfo.RateLimitingCallsRemaining =
+                response.Headers.FirstOrDefault(h => h.Name == "X-RateLimit-Remaining")?.Value?.ToString();
+            _root.LastRequestInfo.RateLimitingTimeTillReset =
+                response.Headers.FirstOrDefault(h => h.Name == "X-RateLimit-Reset")?.Value?.ToString();
         }
 
         private ListPaginated<T> DoRequestList<T>(string urlMethod, Pagination pagination, Dictionary<String, String> additionalUrlParams)
@@ -462,6 +476,8 @@ namespace MangoPay.SDK.Core
 
                 _log.Debug("Response object: " + responseObject.ToString());
             }
+
+            SetLastRequestInfo(restRequest, restResponse);
 
             this.CheckResponseCode(restResponse.Content);
 

--- a/MangoPay.SDK/MangoPay.SDK.csproj
+++ b/MangoPay.SDK/MangoPay.SDK.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Core\FilterMandates.cs" />
     <Compile Include="Core\FilterReports.cs" />
     <Compile Include="Core\FilterReportsList.cs" />
+    <Compile Include="Core\LastRequestInfo.cs" />
     <Compile Include="Core\MangoPayJsonSerializer.cs" />
     <Compile Include="Core\Sort.cs" />
     <Compile Include="Core\TemplateURLOptions.cs" />

--- a/MangoPay.SDK/MangoPayApi.cs
+++ b/MangoPay.SDK/MangoPayApi.cs
@@ -43,6 +43,9 @@ namespace MangoPay.SDK
         /// <summary>Configuration instance with default settings (to be reset if required).</summary>
         public Configuration Config;
 
+        /// <summary>Stores the raw request and response of the last call from this Api instance, including information about rate-limiting.</summary>
+        public LastRequestInfo LastRequestInfo;
+
         #region API managers
 
         /// <summary>Provides OAuth methods.</summary>


### PR DESCRIPTION
MangoPay has transparent rate-limiting info in the HTTP headers of the call.  But there is no access to this through the SDK so I've exposed it on the MangoApi object.