### PR TITLE
Fix BadRequest Error message

### DIFF
--- a/MangoPay.SDK.Tests/ApiUsersTest.cs
+++ b/MangoPay.SDK.Tests/ApiUsersTest.cs
@@ -1043,7 +1043,7 @@ namespace MangoPay.SDK.Tests
             }
             catch (Exception e)
             {
-                Assert.IsTrue(e.Message.Contains("BadRequest"));
+                Assert.IsTrue(e.Message.Contains("The Birthday field is required"), e.Message);
             }
         }
 
@@ -1122,7 +1122,7 @@ namespace MangoPay.SDK.Tests
             }
             catch (Exception e)
             {
-                Assert.IsTrue(e.Message.Contains("BadRequest"));
+                Assert.IsTrue(e.Message.Contains("The HeadquartersAddress field is required"), e.Message);
             }
         }
     }

--- a/MangoPay.SDK/Core/RestTool.cs
+++ b/MangoPay.SDK/Core/RestTool.cs
@@ -23,7 +23,7 @@ namespace MangoPay.SDK.Core
         {
             _options = new RestClientOptions(url)
             {
-                ThrowOnAnyError = true,
+                ThrowOnAnyError = false,
                 Timeout = timeout
             };
 


### PR DESCRIPTION
Asynchronous requests get a "Request failed with status code BadRequest" message in case of error (404). 
The "ThrowOnAnyError = false" allows the SDK to manage actual Mangopay Response and have better information.