### PR TITLE
Compatibility with .NET Framework

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,5 +30,7 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build -c Release --no-restore
-    - name: Test
+    - name: Test .NET 6.0
       run: dotnet test ./MangoPay.SDK.Tests/bin/Release/net6.0/MangoPay.SDK.Tests.dll
+    - name: Test .NET 4.8
+      run: dotnet test ./MangoPay.SDK.Tests/bin/Release/net48/MangoPay.SDK.Tests.dll

--- a/MangoPay.SDK.Tests/ApiKycTest.cs
+++ b/MangoPay.SDK.Tests/ApiKycTest.cs
@@ -77,7 +77,7 @@ namespace MangoPay.SDK.Tests
 
                 var assembly = Assembly.GetExecutingAssembly();
                 var fi = this.GetFileInfoOfFile(assembly.Location);
-                var bytes = await File.ReadAllBytesAsync(fi.FullName);
+                var bytes = File.ReadAllBytes(fi.FullName);
 				await Api.Users.CreateKycPageAsync(john.Id, kycDocument.Id, bytes);
 				await Api.Users.CreateKycPageAsync(john.Id, kycDocument.Id, bytes);
 

--- a/MangoPay.SDK.Tests/ApiUsersTest.cs
+++ b/MangoPay.SDK.Tests/ApiUsersTest.cs
@@ -628,7 +628,7 @@ namespace MangoPay.SDK.Tests
 
                 var assembly = Assembly.GetExecutingAssembly();
                 var fi = this.GetFileInfoOfFile(assembly.Location);
-                var bytes = await File.ReadAllBytesAsync(fi.FullName);
+                var bytes = File.ReadAllBytes(fi.FullName);
 
                 await this.Api.Users.CreateKycPageAsync(john.Id, kycDocument.Id, bytes);
             }

--- a/MangoPay.SDK.Tests/MangoPay.SDK.Tests.csproj
+++ b/MangoPay.SDK.Tests/MangoPay.SDK.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <DebugType>Full</DebugType>
-    <TargetFrameworks>net48;.net6</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0</TargetFrameworks>
     <Company>MangoPay</Company>
     <Copyright>Copyright © 2020</Copyright>
     <Description>.Net MangoPay Tests</Description>

--- a/MangoPay.SDK.Tests/MangoPay.SDK.Tests.csproj
+++ b/MangoPay.SDK.Tests/MangoPay.SDK.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <DebugType>Full</DebugType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;.net6</TargetFrameworks>
     <Company>MangoPay</Company>
     <Copyright>Copyright © 2020</Copyright>
     <Description>.Net MangoPay Tests</Description>
@@ -9,7 +9,6 @@
     <Version>1.0.0</Version>
     <AssemblyVersion>1.4.2.0</AssemblyVersion>
     <FileVersion>1.4.2.0</FileVersion>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
@@ -24,6 +23,7 @@
     <PackageReference Include="Common.Logging" Version="3.4.1" />
     <PackageReference Include="Common.Logging.Core" Version="3.4.1" />
     <PackageReference Include="RestSharp" Version="107.3.0" />
+    <PackageReference Include="System.Net.Http" Version="4.0.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MangoPay.SDK\MangoPay.SDK.csproj" />

--- a/MangoPay.SDK/Core/RestTool.cs
+++ b/MangoPay.SDK/Core/RestTool.cs
@@ -212,7 +212,8 @@ namespace MangoPay.SDK.Core
             var headers = await this.GetHttpHeadersAsync(restUrl);
             foreach (var h in headers)
             {
-                restRequest.AddHeader(h.Key, h.Value);
+                if (!(h.Key == Constants.CONTENT_TYPE && this._requestType == RequestType.GET))
+                    restRequest.AddHeader(h.Key, h.Value);
 
                 if (h.Key != Constants.AUTHORIZATION)
                     _log.Debug("HTTP Header: " + h.Key + ": " + h.Value);
@@ -334,7 +335,8 @@ namespace MangoPay.SDK.Core
             var headers = await this.GetHttpHeadersAsync(restUrl);
             foreach (var h in headers)
             {
-                restRequest.AddHeader(h.Key, h.Value);
+                if (!(h.Key == Constants.CONTENT_TYPE && this._requestType == RequestType.GET))
+                    restRequest.AddHeader(h.Key, h.Value);
 
                 if (h.Key != Constants.AUTHORIZATION)
                     _log.Debug("HTTP Header: " + h.Key + ": " + h.Value);

--- a/MangoPay.SDK/Core/RestTool.cs
+++ b/MangoPay.SDK/Core/RestTool.cs
@@ -136,9 +136,12 @@ namespace MangoPay.SDK.Core
                 case 401:
                     throw new UnauthorizedAccessException(restResponse.Content);
             }
-
+            
             if (restResponse.ResponseStatus == ResponseStatus.TimedOut)
                 throw new TimeoutException(restResponse.ErrorMessage);
+
+            if (restResponse.ErrorException is System.Net.ProtocolViolationException)
+                throw restResponse.ErrorException;
 
             throw new ResponseException(restResponse.Content, responseCode);
         }

--- a/MangoPay.SDK/MangoPay.SDK.csproj
+++ b/MangoPay.SDK/MangoPay.SDK.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Company>MangoPay</Company>
         <Copyright>Copyright © 2022</Copyright>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ MangopaySDK is a Microsoft .NET client library to work with
 
 Installation and package dependencies
 -------------------------------------------------
-This SDK is currently targeting **.NET Standard 2.1** and **.NET 6.0.** It has **4** dependencies on external packages. 
+This SDK is currently targeting **.NET Standard 2.0** and **.NET 6.0.** It has **4** dependencies on external packages. 
 These dependencies are:
 - Common.Logging library (version 3.4.1)
 - Newtonsoft.Json (version 13.0.1)


### PR DESCRIPTION
Summary of the changes:

 - The SDK compilation now targets .NET Standard 2.0 instead of .NET Standard 2.1 (and will keep targeting .NET 6 as well).
 - The code compiles fine on .NET Standard 2.0 without changes.
 - However, there is a difference in runtime behavior between the 2 frameworks. In particular, RestSharp uses a different HTTP client under the hood for .NET 4.x and .NET 5+. On .NET 4.x, the HTTP client throws an exception when a 'Content-Type' HTTP header is passed to GET requests. I made 2 changes to fix this problem: 1) I made sure that this protocol exception is properly thrown when it happens (before, it would trigger a NullReferenceException). 2) I excluded the 'Content-Type' header from GET requests (from the HTTP specifications, this header only applies to requests that have a body).
 - I made sure the unit tests run on both .NET 6 and .NET 4.8 to make sure that both underlying HTTP implementations are tested.
