### PR TITLE
Add RateLimitingCallsMade to LastRequestInfo ("x-ratelimit")

### DIFF
--- a/MangoPay.SDK/Core/LastRequestInfo.cs
+++ b/MangoPay.SDK/Core/LastRequestInfo.cs
@@ -9,6 +9,7 @@ namespace MangoPay.SDK.Core
         public RestResponse Response { get; set; }
 
         public string RateLimitingCallsAllowed { get; set; }
+        public string RateLimitingCallsMade { get; set; }
 
         public string RateLimitingCallsRemaining { get; set; }
 

--- a/MangoPay.SDK/Core/LastRequestInfo.cs
+++ b/MangoPay.SDK/Core/LastRequestInfo.cs
@@ -9,6 +9,7 @@ namespace MangoPay.SDK.Core
         public RestResponse Response { get; set; }
 
         public string RateLimitingCallsAllowed { get; set; }
+
         public string RateLimitingCallsMade { get; set; }
 
         public string RateLimitingCallsRemaining { get; set; }

--- a/MangoPay.SDK/Core/RestTool.cs
+++ b/MangoPay.SDK/Core/RestTool.cs
@@ -298,6 +298,7 @@ namespace MangoPay.SDK.Core
             _root.LastRequestInfo.RateLimitingCallsAllowed = GetHeaderValue("X-RateLimit-Limit");
             _root.LastRequestInfo.RateLimitingCallsRemaining = GetHeaderValue("X-RateLimit-Remaining");
             _root.LastRequestInfo.RateLimitingTimeTillReset = GetHeaderValue("X-RateLimit-Reset");
+            _root.LastRequestInfo.RateLimitingCallsMade = GetHeaderValue("X-RateLimit");
         }
 
         private async Task<ListPaginated<T>> DoRequestListAsync<T>(string urlMethod, Dictionary<string, string> additionalUrlParams = null,


### PR DESCRIPTION
Hi,

In the docs https://docs.mangopay.com/api-reference/overview/rate-limiting, it is stated that : 
`x-ratelimit indicates the number of API calls you have made.`

But we don't have this info in the LastRequestInfo, so this is PR is addressing it.

Also, "X-RateLimit-Limit" (RateLimitingCallsAllowed) doesn't seem to be returned in headers and isn't stated in the rate-limiting docs. It might be better to just remove this property from the SDK. 