### PR TITLE
Upgrades RestSharp from v107.3.0 to v112.1.0 

### DIFF
--- a/MangoPay.SDK.Tests/MangoPay.SDK.Tests.csproj
+++ b/MangoPay.SDK.Tests/MangoPay.SDK.Tests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Common.Logging" Version="3.4.1" />
     <PackageReference Include="Common.Logging.Core" Version="3.4.1" />
-    <PackageReference Include="RestSharp" Version="107.3.0" />
+    <PackageReference Include="RestSharp" Version="112.1.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup>

--- a/MangoPay.SDK/Core/MangoPayJsonSerializer.cs
+++ b/MangoPay.SDK/Core/MangoPayJsonSerializer.cs
@@ -1,11 +1,12 @@
 ﻿using Newtonsoft.Json;
+using RestSharp;
 using RestSharp.Serializers;
 
 namespace MangoPay.SDK.Core
 {
     public sealed class MangoPayJsonSerializer : ISerializer
     {
-        public string ContentType { get; set; }
+        public ContentType ContentType { get; set; }
 
         public string Serialize(object obj)
         {

--- a/MangoPay.SDK/Core/RestTool.cs
+++ b/MangoPay.SDK/Core/RestTool.cs
@@ -1,11 +1,11 @@
-﻿using Common.Logging;
-using MangoPay.SDK.Entities;
-using RestSharp;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Common.Logging;
+using MangoPay.SDK.Entities;
+using RestSharp;
 
 namespace MangoPay.SDK.Core
 {
@@ -24,11 +24,10 @@ namespace MangoPay.SDK.Core
             _options = new RestClientOptions(url)
             {
                 ThrowOnAnyError = false,
-                Timeout = timeout
+                Timeout = new TimeSpan(timeout)
             };
 
-            Client = new RestClient(_options);
-            Client.UseSerializer<MangoPaySerializer>();
+            Client = new RestClient(_options, configureSerialization: s => s.UseSerializer(() => new MangoPaySerializer()));
         }
 
         public static RestSharpDto GetInstance(string url, int timeout)
@@ -140,7 +139,7 @@ namespace MangoPay.SDK.Core
             if (restResponse.ResponseStatus == ResponseStatus.TimedOut)
                 throw new TimeoutException(restResponse.ErrorMessage);
 
-            if (restResponse.ErrorException is System.Net.ProtocolViolationException)
+            if (restResponse.ErrorException is ProtocolViolationException)
                 throw restResponse.ErrorException;
 
             throw new ResponseException(restResponse.Content, responseCode);

--- a/MangoPay.SDK/MangoPay.SDK.csproj
+++ b/MangoPay.SDK/MangoPay.SDK.csproj
@@ -21,7 +21,7 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="Common.Logging" Version="3.4.1" />
       <PackageReference Include="Common.Logging.Core" Version="3.4.1" />
-      <PackageReference Include="RestSharp" Version="107.3.0" />
+      <PackageReference Include="RestSharp" Version="112.1.0" />
     </ItemGroup>
 </Project>
 


### PR DESCRIPTION
Necessary in order to fix CRLF Injection in RestSharp's `RestRequest.AddHeader` method