### PR TITLE
CardInfoType can be nullable in some case when using WithNext payment provider

### DIFF
--- a/MangoPay.SDK/Entities/CardInfo.cs
+++ b/MangoPay.SDK/Entities/CardInfo.cs
@@ -15,7 +15,7 @@ namespace MangoPay.SDK.Entities
         public CountryIso IssuerCountryCode;
 
         /// <summary>The type of card product: DEBIT, CREDIT, CHARGE CARD.</summary>
-        public CardInfoType Type;
+        public CardInfoType? Type;
         
         /// <summary>The card brand. Examples include: AMERICAN EXPRESS, DISCOVER, JCB, MASTERCARD, VISA, etc.</summary>
         public string Brand;


### PR DESCRIPTION
Sometimes with some card in case of a direct card payment, and if MangoPay use the provider WithNext, the response API of the API path https://api.mangopay.com/v2.01/leetchi/payins/card/direct has a sub type CardInfo like:

> "CardInfo": {
            "BIN": "46338910",
            "IssuingBank": null,
            "IssuerCountryCode": "FR",
            "Type": null,
            "Brand": "VISA",
            "SubType": "PURCHASING"
        }

The Type field is null and this is not supported by the deserializer of restSharp which throw an exception but ignored and the sdk return in this case a Dto with all property null.
