### PR TITLE
Add CUSTOMER_DISPUTE to enum DisputeReasonType.

### DIFF
--- a/MangoPay.SDK/Core/Enumerations/DisputeReasonType.cs
+++ b/MangoPay.SDK/Core/Enumerations/DisputeReasonType.cs
@@ -38,6 +38,8 @@ namespace MangoPay.SDK.Core.Enumerations
 
 		REFUND_NOT_PROCESSED,
 		
-		COUNTERFEIT_PRODUCT
+		COUNTERFEIT_PRODUCT,
+
+		CUSTOMER_DISPUTE
 	}
 }


### PR DESCRIPTION
Add missing `CUSTOMER_DISPUTE` value to enum `DisputeReasonType`. 
This value can be received when calling `mangoPayApi.Disputes.GetDisputesPendingSettlementAsync()`